### PR TITLE
Fix relative config path resolution

### DIFF
--- a/QKD_Mate/config/alice.yaml
+++ b/QKD_Mate/config/alice.yaml
@@ -1,4 +1,4 @@
-extends: "config/common.yaml"
+extends: "common.yaml"
 endpoint: "https://78.40.171.143:443"
 cert: "certs/client_Alice2.crt"
 key:  "certs/client_Alice2.key"

--- a/QKD_Mate/config/bob.yaml
+++ b/QKD_Mate/config/bob.yaml
@@ -1,4 +1,4 @@
-extends: "config/common.yaml"
+extends: "common.yaml"
 endpoint: "https://78.40.171.144:443"
 cert: "certs/client_Bob2.crt"
 key:  "certs/client_Bob2.key"

--- a/QKD_Mate/src/alice_client.py
+++ b/QKD_Mate/src/alice_client.py
@@ -1,4 +1,8 @@
+from pathlib import Path
 from .client import QKDClient
 
 def alice_client() -> QKDClient:
-    return QKDClient("config/alice.yaml")
+    # Get the path relative to this module's location
+    module_dir = Path(__file__).parent.parent  # Go up from src/ to QKD_Mate/
+    config_path = module_dir / "config" / "alice.yaml"
+    return QKDClient(config_path)

--- a/QKD_Mate/src/bob_client.py
+++ b/QKD_Mate/src/bob_client.py
@@ -1,4 +1,8 @@
+from pathlib import Path
 from .client import QKDClient
 
 def bob_client() -> QKDClient:
-    return QKDClient("config/bob.yaml")
+    # Get the path relative to this module's location
+    module_dir = Path(__file__).parent.parent  # Go up from src/ to QKD_Mate/
+    config_path = module_dir / "config" / "bob.yaml"
+    return QKDClient(config_path)

--- a/QKD_Mate/src/client.py
+++ b/QKD_Mate/src/client.py
@@ -8,6 +8,7 @@ import yaml
 from .utils import retry, QKDClientError
 
 def _load_yaml(path: str | Path) -> dict:
+    path = Path(path).resolve()  # Convert to absolute path
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f) or {}
 
@@ -30,9 +31,12 @@ class QKDClient:
       - api_paths: {status: "/api/status", keys: "/api/keys"}
     """
     def __init__(self, config_path: str | Path):
+        config_path = Path(config_path).resolve()
         cfg = _load_yaml(config_path)
         if "extends" in cfg:
-            common = _load_yaml(cfg["extends"])
+            # Resolve extends path relative to the config file's directory
+            extends_path = config_path.parent / cfg["extends"]
+            common = _load_yaml(extends_path)
             cfg = _merge(common, {k: v for k, v in cfg.items() if k != "extends"})
         self.base_url: str = cfg["endpoint"].rstrip("/")
         self.cert = (cfg["cert"], cfg["key"])


### PR DESCRIPTION
Make configuration loading CWD-independent to allow scripts to run from any directory.

The original setup caused issues when running scripts from subdirectories (e.g., `examples/`) because `extends` paths in config files and the paths used by client factory functions were resolved relative to the Current Working Directory. This led to `FileNotFoundError` as the system looked for config files in incorrect locations. This PR resolves paths relative to the config file's location or the module's location, ensuring correct loading regardless of where the script is executed.

---
<a href="https://cursor.com/background-agent?bcId=bc-5989a2e9-ac54-4d0d-9a51-dd67dea17dfa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5989a2e9-ac54-4d0d-9a51-dd67dea17dfa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

