### PR TITLE
Setup and configure QKD_Mate on remote server

### DIFF
--- a/fix_qkd_issues.sh
+++ b/fix_qkd_issues.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+echo "==============================================="
+echo "🔧 QKD_Mate Issue Resolution Commands"
+echo "==============================================="
+echo ""
+echo "Run these commands on your Ubuntu server:"
+echo ""
+
+echo "1. 📋 First, let's examine the cert_manager.py file:"
+echo "   cd ~/QKD_mate/QKD_Mate"
+echo "   head -20 cert_manager.py"
+echo "   grep -n 'cert_templates' cert_manager.py"
+echo "   grep -n 'common' cert_manager.py"
+echo ""
+
+echo "2. 🌐 Test basic network connectivity:"
+echo "   ping -c 3 8.8.8.8"
+echo "   ping -c 3 78.40.171.143"
+echo "   telnet 78.40.171.143 443"
+echo "   curl -v --connect-timeout 10 https://78.40.171.143:443"
+echo ""
+
+echo "3. 🔍 Check current configuration:"
+echo "   cat node_config.yaml"
+echo "   ls -la certs/"
+echo ""
+
+echo "4. 📝 List all Python files to understand the structure:"
+echo "   ls -la *.py"
+echo ""
+
+echo "==============================================="
+echo "💡 After running these, we can fix the issues!"
+echo "==============================================="

--- a/ubuntu_setup_commands.sh
+++ b/ubuntu_setup_commands.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+echo "==============================================="
+echo "🔧 QKD_Mate Ubuntu Server Setup Commands"
+echo "==============================================="
+echo ""
+echo "Run these commands on your Ubuntu server (46.62.149.253):"
+echo ""
+
+echo "1. 📦 Install pip and update system:"
+echo "   sudo apt update"
+echo "   sudo apt install -y python3-pip python3-venv"
+echo ""
+
+echo "2. 🔐 Fix certificate permissions:"
+echo "   cd ~/QKD_mate/QKD_Mate"
+echo "   chmod 600 certs/client_Alice2.key"
+echo "   chmod 600 certs/client_Bob2.key"
+echo ""
+
+echo "3. 🐍 Install Python dependencies:"
+echo "   pip3 install --upgrade pip"
+echo "   pip3 install requests urllib3 pyyaml cryptography"
+echo ""
+
+echo "4. ✅ Run the setup again:"
+echo "   python3 quick_start.py"
+echo ""
+
+echo "==============================================="
+echo "Alternative: If pip3 doesn't work, try:"
+echo "   python3 -m pip install --upgrade pip"
+echo "   python3 -m pip install requests urllib3 pyyaml cryptography"
+echo "==============================================="

--- a/ubuntu_venv_setup.sh
+++ b/ubuntu_venv_setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+echo "==============================================="
+echo "🐍 QKD_Mate Virtual Environment Setup"
+echo "==============================================="
+echo ""
+echo "Ubuntu 24.04+ uses externally managed Python environments."
+echo "Here are the solutions (choose ONE):"
+echo ""
+
+echo "🔧 SOLUTION 1: Use Virtual Environment (RECOMMENDED)"
+echo "---------------------------------------------------"
+echo "cd ~/QKD_mate/QKD_Mate"
+echo "python3 -m venv venv"
+echo "source venv/bin/activate"
+echo "pip install --upgrade pip"
+echo "pip install requests urllib3 pyyaml cryptography"
+echo "python3 quick_start.py"
+echo ""
+
+echo "🔧 SOLUTION 2: Install system packages"
+echo "--------------------------------------"
+echo "sudo apt update"
+echo "sudo apt install -y python3-requests python3-urllib3 python3-yaml python3-cryptography"
+echo "python3 quick_start.py"
+echo ""
+
+echo "🔧 SOLUTION 3: Override system protection (NOT RECOMMENDED)"
+echo "----------------------------------------------------------"
+echo "pip3 install --break-system-packages requests urllib3 pyyaml cryptography"
+echo ""
+
+echo "==============================================="
+echo "💡 RECOMMENDED: Use Solution 1 (Virtual Environment)"
+echo "This keeps your system clean and isolated."
+echo "==============================================="


### PR DESCRIPTION
Add `ubuntu_setup_commands.sh` to install pip, fix certificate permissions, and install Python dependencies for QKD_Mate.

This script resolves the "pip not found" error encountered during the QKD_Mate setup on an Ubuntu server, allowing the system to install required Python packages and proceed with configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-ffc308fc-2375-464f-957a-43c98747746c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ffc308fc-2375-464f-957a-43c98747746c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

